### PR TITLE
Make work with latest PHP

### DIFF
--- a/prairie/class/Openid.class.php
+++ b/prairie/class/Openid.class.php
@@ -416,7 +416,7 @@ class OpenidServer {
 				$data_to_send['openid.assoc_handle'] = $this->assoc_handle();
 			}
 			
-			$this->sreg_extention (&$data_to_send);
+			$this->sreg_extention ($data_to_send);
 			
 			
 			$signed = '';


### PR DESCRIPTION
"&"-style references are not allowed any more

This expects to be committed after https://github.com/brockhaus/prairie-openid2-server/commit/dd04df2d3abd8623600107d61b548bf38e2101b6
