### PR TITLE
Login fixes

### DIFF
--- a/prairie/template/login.tpl.php
+++ b/prairie/template/login.tpl.php
@@ -167,11 +167,15 @@
 			if ($_SERVER["REQUEST_METHOD"]=="POST"){
 				reset ($_POST); 
 				foreach ($_POST as $key=>$value) {
+					if (in_array($key, array(login_email,login_password,login_admin)))
+						continue;
 					$fields .= input_($key, $value, "hidden"); 
 				}
 			} else {
 				reset ($_GET); 
 				foreach ($_GET as $key=>$value) {
+					if (in_array($key, array(login_email,login_password,login_admin)))
+						continue;
 					$fields .= input_($key, $value, "hidden"); 
 				}
 			}

--- a/prairie/template/login.tpl.php
+++ b/prairie/template/login.tpl.php
@@ -185,7 +185,7 @@
 			?>
 			<p>
 				<label for="id_login_email"><?php echo _("Email");?></label>
-				<input type="text" id="id_login_email" value="" name="login_email" />
+				<input type="email" id="id_login_email" value="" name="login_email" />
 			</p>
 			<?php }?>
 


### PR DESCRIPTION
- Do not include old passed password or username as hidden form which prevent users from logging in correctly after an invalid login attempte.
- Use an email field in order to prevent spell checking and other autofixing stuff on mobile devices
